### PR TITLE
Added HTML5 importable sources

### DIFF
--- a/dist/jquery.html
+++ b/dist/jquery.html
@@ -1,0 +1,1 @@
+<script src="jquery.js"></script>

--- a/dist/jquery.min.html
+++ b/dist/jquery.min.html
@@ -1,0 +1,1 @@
+<script src="jquery.min.js"></script>

--- a/dist/jquery.slim.html
+++ b/dist/jquery.slim.html
@@ -1,0 +1,1 @@
+<script src="jquery.slim.js"></script>

--- a/dist/jquery.slim.min.html
+++ b/dist/jquery.slim.min.html
@@ -1,0 +1,1 @@
+<script src="jquery.slim.min.js"></script>


### PR DESCRIPTION
I don't know if I should fork this repo, or somewhere within jquery/jquery itself, but it would be very very handy to have HTML5 importable version of jquery (for the sake of Polymer and any future Web Components modules).
Currently every module importing jquery via script tag will re-download it and re-run it. HTML5 Imports will download the source once as long as the URL path does not change. This helps a lot and will make more and more developers use jQuery in their web components.
