### PR TITLE
README: Update release instructions & formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ import $ from "jquery";
 There are several ways to use [Browserify](http://browserify.org/) and [Webpack](https://webpack.github.io/). For more information on using these tools, please refer to the corresponding project's documention. In the script, including jQuery will usually look like this...
 
 ```js
-var $ = require("jquery");
+var $ = require( "jquery" );
 ```
 
 #### AMD (Asynchronous Module Definition)
@@ -40,9 +40,9 @@ var $ = require("jquery");
 AMD is a module format built for the browser. For more information, we recommend [require.js' documentation](http://requirejs.org/docs/whyamd.html).
 
 ```js
-define(["jquery"], function($) {
+define( [ "jquery" ], function( $ ) {
 
-});
+} );
 ```
 
 ### Node
@@ -56,12 +56,7 @@ npm install jquery
 For jQuery to work in Node, a window with a document is required. Since no such window exists natively in Node, one can be mocked by tools such as [jsdom](https://github.com/tmpvar/jsdom). This can be useful for testing purposes.
 
 ```js
-require("jsdom").env("", function(err, window) {
-	if (err) {
-		console.error(err);
-		return;
-	}
-
-	var $ = require("jquery")(window);
-});
+const { JSDOM } = require( "jsdom" );
+const { window } = new JSDOM( "" );
+const $ = require( "jquery" )( window );
 ```


### PR DESCRIPTION
The previous jsdom API is no longer supported in its latest version. README
was updated.

Fixes jquery/jquery#4546

@timmywil README is maintained directly in this repo, only `src`, `external` & `dist` directories are published from outside? Do I understand it right?